### PR TITLE
Avoid early translation calls before init

### DIFF
--- a/includes/class-wp-error-notify-settings.php
+++ b/includes/class-wp-error-notify-settings.php
@@ -122,25 +122,45 @@ class WP_Error_Notify_Settings {
 	 * 利用可能な全PHPエラーレベルとその説明(翻訳対応)のリストを取得する(静的メソッド)。
 	 * @return array エラーレベルコード => 説明文字列 の連想配列
 	 */
-	public static function get_all_error_levels() {
-		return [
-			E_ERROR             => __('Fatal run-time errors. (E_ERROR)', 'wp-error-notify'),
-			E_WARNING           => __('Run-time warnings (non-fatal errors). (E_WARNING)', 'wp-error-notify'),
-			E_PARSE             => __('Compile-time parse errors. (E_PARSE)', 'wp-error-notify'),
-			E_NOTICE            => __('Run-time notices. (E_NOTICE)', 'wp-error-notify'),
-			E_CORE_ERROR        => __('Fatal errors that occur during PHP\'s initial startup. (E_CORE_ERROR)', 'wp-error-notify'),
-			E_CORE_WARNING      => __('Warnings (non-fatal errors) that occur during PHP\'s initial startup. (E_CORE_WARNING)', 'wp-error-notify'),
-			E_COMPILE_ERROR     => __('Fatal compile-time errors. (E_COMPILE_ERROR)', 'wp-error-notify'),
-			E_COMPILE_WARNING   => __('Compile-time warnings (non-fatal errors). (E_COMPILE_WARNING)', 'wp-error-notify'),
-			E_USER_ERROR        => __('User-generated error message. (E_USER_ERROR)', 'wp-error-notify'),
-			E_USER_WARNING      => __('User-generated warning message. (E_USER_WARNING)', 'wp-error-notify'),
-			E_USER_NOTICE       => __('User-generated notice message. (E_USER_NOTICE)', 'wp-error-notify'),
-			E_STRICT            => __('Enable to have PHP suggest changes to your code which will ensure the best interoperability and forward compatibility of your code. (E_STRICT)', 'wp-error-notify'),
-			E_RECOVERABLE_ERROR => __('Catchable fatal error. (E_RECOVERABLE_ERROR)', 'wp-error-notify'),
-			E_DEPRECATED        => __('Run-time notices. Enable to receive warnings about code that will not work in future versions. (E_DEPRECATED)', 'wp-error-notify'),
-			E_USER_DEPRECATED   => __('User-generated warning message. (E_USER_DEPRECATED)', 'wp-error-notify'),
-		];
-	}
+        public static function get_all_error_levels() {
+                if ( did_action( 'init' ) ) {
+                        return [
+                                E_ERROR             => __('Fatal run-time errors. (E_ERROR)', 'wp-error-notify'),
+                                E_WARNING           => __('Run-time warnings (non-fatal errors). (E_WARNING)', 'wp-error-notify'),
+                                E_PARSE             => __('Compile-time parse errors. (E_PARSE)', 'wp-error-notify'),
+                                E_NOTICE            => __('Run-time notices. (E_NOTICE)', 'wp-error-notify'),
+                                E_CORE_ERROR        => __('Fatal errors that occur during PHP\'s initial startup. (E_CORE_ERROR)', 'wp-error-notify'),
+                                E_CORE_WARNING      => __('Warnings (non-fatal errors) that occur during PHP\'s initial startup. (E_CORE_WARNING)', 'wp-error-notify'),
+                                E_COMPILE_ERROR     => __('Fatal compile-time errors. (E_COMPILE_ERROR)', 'wp-error-notify'),
+                                E_COMPILE_WARNING   => __('Compile-time warnings (non-fatal errors). (E_COMPILE_WARNING)', 'wp-error-notify'),
+                                E_USER_ERROR        => __('User-generated error message. (E_USER_ERROR)', 'wp-error-notify'),
+                                E_USER_WARNING      => __('User-generated warning message. (E_USER_WARNING)', 'wp-error-notify'),
+                                E_USER_NOTICE       => __('User-generated notice message. (E_USER_NOTICE)', 'wp-error-notify'),
+                                E_STRICT            => __('Enable to have PHP suggest changes to your code which will ensure the best interoperability and forward compatibility of your code. (E_STRICT)', 'wp-error-notify'),
+                                E_RECOVERABLE_ERROR => __('Catchable fatal error. (E_RECOVERABLE_ERROR)', 'wp-error-notify'),
+                                E_DEPRECATED        => __('Run-time notices. Enable to receive warnings about code that will not work in future versions. (E_DEPRECATED)', 'wp-error-notify'),
+                                E_USER_DEPRECATED   => __('User-generated warning message. (E_USER_DEPRECATED)', 'wp-error-notify'),
+                        ];
+                }
+
+                return [
+                        E_ERROR             => 'Fatal run-time errors. (E_ERROR)',
+                        E_WARNING           => 'Run-time warnings (non-fatal errors). (E_WARNING)',
+                        E_PARSE             => 'Compile-time parse errors. (E_PARSE)',
+                        E_NOTICE            => 'Run-time notices. (E_NOTICE)',
+                        E_CORE_ERROR        => 'Fatal errors that occur during PHP\'s initial startup. (E_CORE_ERROR)',
+                        E_CORE_WARNING      => 'Warnings (non-fatal errors) that occur during PHP\'s initial startup. (E_CORE_WARNING)',
+                        E_COMPILE_ERROR     => 'Fatal compile-time errors. (E_COMPILE_ERROR)',
+                        E_COMPILE_WARNING   => 'Compile-time warnings (non-fatal errors). (E_COMPILE_WARNING)',
+                        E_USER_ERROR        => 'User-generated error message. (E_USER_ERROR)',
+                        E_USER_WARNING      => 'User-generated warning message. (E_USER_WARNING)',
+                        E_USER_NOTICE       => 'User-generated notice message. (E_USER_NOTICE)',
+                        E_STRICT            => 'Enable to have PHP suggest changes to your code which will ensure the best interoperability and forward compatibility of your code. (E_STRICT)',
+                        E_RECOVERABLE_ERROR => 'Catchable fatal error. (E_RECOVERABLE_ERROR)',
+                        E_DEPRECATED        => 'Run-time notices. Enable to receive warnings about code that will not work in future versions. (E_DEPRECATED)',
+                        E_USER_DEPRECATED   => 'User-generated warning message. (E_USER_DEPRECATED)',
+                ];
+        }
 
 	/**
 	 * エラータイプコードを人間可読な文字列(翻訳対応)に変換する。
@@ -149,8 +169,13 @@ class WP_Error_Notify_Settings {
 	 */
 	public function get_error_type_name( int $type ): string {
 		$levels = self::get_all_error_levels();
-		return isset( $levels[$type] ) ? $levels[$type] : sprintf( __( 'Unknown error type (%d)', 'wp-error-notify' ), $type );
-	}
+                if ( isset( $levels[$type] ) ) {
+                        return $levels[$type];
+                }
+
+                $unknown_label = did_action( 'init' ) ? __( 'Unknown error type (%d)', 'wp-error-notify' ) : 'Unknown error type (%d)';
+                return sprintf( $unknown_label, $type );
+        }
 
 	/**
 	 * DBアクセスが失敗したとマークする。


### PR DESCRIPTION
## Summary
- avoid calling translation functions before the `init` hook by adding safe fallbacks in the error handler
- return untranslated strings before init in the settings class so error level labels remain available without triggering notices

## Testing
- php -l includes/class-wp-error-notify-handler.php
- php -l includes/class-wp-error-notify-settings.php

------
https://chatgpt.com/codex/tasks/task_e_68d5f09c4c7083308f4677b4b42804b2