### PR TITLE
Load translations before error handling runs

### DIFF
--- a/wp-error-notify.php
+++ b/wp-error-notify.php
@@ -56,8 +56,8 @@ function wp_error_notify_init() {
 }
 add_action( 'plugins_loaded', 'wp_error_notify_init', 1);
 
-// 国際化対応
-add_action( 'init', function () {
+// 国際化対応: plugins_loaded の早い段階で読み込むことで init 前の翻訳呼び出しでもドメインが確実に利用可能となる
+add_action( 'plugins_loaded', function () {
     load_plugin_textdomain(
         'wp-error-notify',
         false,


### PR DESCRIPTION
## Summary
- revert the temporary translation fallbacks so notifications keep their localized copy
- load the text domain during `plugins_loaded` to avoid the early `_load_textdomain_just_in_time` notice while keeping translations available

## Testing
- php -l includes/class-wp-error-notify-handler.php
- php -l includes/class-wp-error-notify-settings.php
- php -l wp-error-notify.php

------
https://chatgpt.com/codex/tasks/task_e_68d5f09c4c7083308f4677b4b42804b2